### PR TITLE
Fixed NumericNode behavior with empty/nil text values

### DIFF
--- a/lib/xml/mapping/standard_nodes.rb
+++ b/lib/xml/mapping/standard_nodes.rb
@@ -6,7 +6,7 @@ module XML
   module Mapping
 
     # Node factory function synopsis:
-    # 
+    #
     #   text_node :_attrname_, _path_ [, :default_value=>_obj_]
     #                                 [, :optional=>true]
     #                                 [, :mapping=>_m_]
@@ -34,7 +34,7 @@ module XML
     end
 
     # Node factory function synopsis:
-    # 
+    #
     #   numeric_node :_attrname_, _path_ [, :default_value=>_obj_]
     #                                    [, :optional=>true]
     #                                    [, :mapping=>_m_]
@@ -48,14 +48,22 @@ module XML
         @path = XML::XXPath.new(path)
         args
       end
+
       def extract_attr_value(xml) # :nodoc:
         txt = default_when_xpath_err{ @path.first(xml).text }
-        begin
-          Integer(txt)
-        rescue ArgumentError
-          Float(txt)
+
+        if txt.nil? or txt.empty?
+          raise 'No default value for empty numeric value' if @options[:default_value].nil?
+          @options[:default_value]
+        else
+          begin
+            Integer(txt)
+          rescue ArgumentError
+            Float(txt)
+          end
         end
       end
+
       def set_attr_value(xml, value) # :nodoc:
         raise RuntimeError, "Not an integer: #{value}" unless Numeric===value
         @path.first(xml,:ensure_created=>true).text = value.to_s
@@ -136,7 +144,7 @@ module XML
     require 'xml/mapping/core_classes_mapping'
 
     # Node factory function synopsis:
-    # 
+    #
     #   object_node :_attrname_, _path_ [, :default_value=>_obj_]
     #                                   [, :optional=>true]
     #                                   [, :class=>_c_]
@@ -171,7 +179,7 @@ module XML
     end
 
     # Node factory function synopsis:
-    # 
+    #
     #   boolean_node :_attrname_, _path_,
     #                _true_value_, _false_value_ [, :default_value=>_obj_]
     #                                            [, :optional=>true]
@@ -202,7 +210,7 @@ module XML
     end
 
     # Node factory function synopsis:
-    # 
+    #
     #   array_node :_attrname_, _per_arrelement_path_
     #                     [, :default_value=>_obj_]
     #                     [, :optional=>true]
@@ -290,7 +298,7 @@ module XML
 
 
     # Node factory function synopsis:
-    # 
+    #
     #   hash_node :_attrname_, _per_hashelement_path_, _key_path_
     #                     [, :default_value=>_obj_]
     #                     [, :optional=>true]
@@ -383,14 +391,14 @@ module XML
             # mechanism (a flag with dynamic scope probably) to tell
             # the node factory fcn not to add the node to the
             # xml_mapping_nodes
-            @owner.xml_mapping_nodes(:mapping=>@mapping).delete arg 
+            @owner.xml_mapping_nodes(:mapping=>@mapping).delete arg
             path=nil
           end
         end
 
         raise XML::MappingError, "node missing at end of argument list" unless path.nil?
         raise XML::MappingError, "no choices were supplied" if @choices.empty?
-        
+
         []
       end
 

--- a/test/fixtures/number.xml
+++ b/test/fixtures/number.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<number>
+  <value/>
+</number>

--- a/test/number.rb
+++ b/test/number.rb
@@ -1,0 +1,11 @@
+require 'xml/mapping'
+
+class Number
+  include XML::Mapping
+
+  use_mapping :no_default
+  numeric_node :value, 'value'
+
+  use_mapping :with_default
+  numeric_node :value, 'value', default_value: 0
+end

--- a/test/xml_mapping_test.rb
+++ b/test/xml_mapping_test.rb
@@ -46,6 +46,22 @@ class XmlMappingTest < Test::Unit::TestCase
     assert_equal 18, @c.offices[1].address.number
   end
 
+  def test_int_node_default_value
+    require 'number'
+    xml = REXML::Document.new(File.new(File.dirname(__FILE__) + "/fixtures/number.xml"))
+
+    assert_raise RuntimeError, 'No default value for empty numeric value' do
+      Number.load_from_xml(xml.root, :mapping => :no_default)
+    end
+
+    num = nil
+    assert_nothing_raised do
+      num = Number.load_from_xml(xml.root, :mapping => :with_default)
+    end
+
+    assert_equal 0, num.value
+  end
+
   def test_getter_boolean_node
     path=XML::XXPath.new("offices/office[2]/classified")
     assert_equal(path.first(@xml.root).text == "yes",
@@ -189,22 +205,22 @@ class XmlMappingTest < Test::Unit::TestCase
     @c.ent2 = "lalala"
     assert_equal "lalala", REXML::XPath.first(@c.save_to_xml, "arrtest/entry[2]").text
   end
-  
-  
+
+
   def test_setter_array_node
     xml=@c.save_to_xml
     assert_equal ["pencils", "weapons of mass destruction"],
           XML::XXPath.new("offices/office/@speciality").all(xml).map{|n|n.text}
   end
-  
-  
+
+
   def test_setter_hash_node
     xml=@c.save_to_xml
     assert_equal @c.customers.keys.sort,
           XML::XXPath.new("customers/customer/@uid").all(@xml.root).map{|n|n.text}.sort
   end
-  
-  
+
+
   def test_setter_boolean_node
     @c.offices[0].classified = !@c.offices[0].classified
     xml=@c.save_to_xml


### PR DESCRIPTION
When a numeric node finds an empty value at its configured path, it should not throw if a default value had been provided.