### PR TITLE
(Ruby 2.5) Support multiple arguments to Kernel#warn

### DIFF
--- a/lib/xml/rexml_ext.rb
+++ b/lib/xml/rexml_ext.rb
@@ -152,7 +152,7 @@ begin
   # temporarily suppress warnings
   class <<Kernel
     alias_method :old_warn, :warn
-    def warn(msg)
+    def warn(*args)
     end
   end
   begin


### PR DESCRIPTION
Loading the REXML extension currently fails when using Ruby 2.5.0 because `Kernel#warn` supports multiple arguments.